### PR TITLE
feat: integrate team builder add flow with existing saved-player API

### DIFF
--- a/client/src/pages/TeamBuilderPage/TeamBuilderPage.module.css
+++ b/client/src/pages/TeamBuilderPage/TeamBuilderPage.module.css
@@ -67,6 +67,12 @@
   opacity: 0.6;
 }
 
+.playerError {
+  font-size: 12px;
+  color: #ff8a8a;
+  margin-top: 6px;
+}
+
 /* Search + Load a team section */
 .searchSection {
   background: rgba(16, 17, 30, 0.95);

--- a/client/src/pages/TeamBuilderPage/TeamBuilderPage.tsx
+++ b/client/src/pages/TeamBuilderPage/TeamBuilderPage.tsx
@@ -57,6 +57,8 @@ export default function TeamBuilderPage() {
   const [savedTeams, setSavedTeams] = useState<SavedTeam[]>([]);
   const [salaryRange, setSalaryRange] = useState<[number, number]>([0, 100000000]);
   const [selectedPositions, setSelectedPositions] = useState<Set<string>>(new Set(positionOrder));
+  const [savingPlayerIds, setSavingPlayerIds] = useState<Set<number>>(() => new Set());
+  const [playerOperationError, setPlayerOperationError] = useState("");
 
   // Load saved teams from localStorage on mount
   useEffect(() => {
@@ -81,6 +83,30 @@ export default function TeamBuilderPage() {
 
     void fetchSaved();
   }, []);
+
+  const ensurePlayerIsSaved = useCallback(
+    async (player: SavedPlayer) => {
+      if (savedPlayers.some((saved) => saved.id === player.id)) {
+        return true;
+      }
+
+      const result = await playerActions.addPlayer({
+        id: player.id,
+        name: player.name,
+        image_url: player.image_url,
+        years_active: player.years_active
+      });
+
+      if (result.success) {
+        setSavedPlayers((prev) => [...prev, player]);
+        return true;
+      }
+
+      setPlayerOperationError(result.error || "Failed to save player");
+      return false;
+    },
+    [savedPlayers]
+  );
 
   const performSearch = useCallback(async (query: string) => {
     const trimmed = query.trim();
@@ -158,6 +184,35 @@ export default function TeamBuilderPage() {
 
     setActivePosition(position);
   }, []);
+
+  const handleAddPlayer = useCallback(
+    async (player: SavedPlayer) => {
+      if (!activePosition) {
+        return;
+      }
+
+      setPlayerOperationError("");
+      setSavingPlayerIds((prev) => {
+        const next = new Set(prev);
+        next.add(player.id);
+        return next;
+      });
+
+      try {
+        const saved = await ensurePlayerIsSaved(player);
+        if (saved) {
+          assignPlayerToPosition(player, activePosition);
+        }
+      } finally {
+        setSavingPlayerIds((prev) => {
+          const next = new Set(prev);
+          next.delete(player.id);
+          return next;
+        });
+      }
+    },
+    [activePosition, assignPlayerToPosition, ensurePlayerIsSaved]
+  );
 
   const handleClearSlot = (position: DiamondPosition) => {
     setLineup((prev) => ({
@@ -283,6 +338,10 @@ export default function TeamBuilderPage() {
             <div className={styles.searchStatus}>
               {searchTerm.trim() ? `${availablePlayers.length} results` : `${savedPlayers.length} saved players`}
             </div>
+
+            {playerOperationError && (
+              <p className={styles.playerError}>{playerOperationError}</p>
+            )}
 
             <div className={styles.searchActions}>
               <button 
@@ -456,9 +515,15 @@ export default function TeamBuilderPage() {
 
                     <button
                       className={styles.addButton}
-                      disabled={alreadyAssigned || !activePosition}
+                      disabled={
+                        alreadyAssigned ||
+                        !activePosition ||
+                        savingPlayerIds.has(player.id)
+                      }
                       onClick={() => {
-                        if (activePosition) assignPlayerToPosition(player, activePosition);
+                        if (activePosition) {
+                          void handleAddPlayer(player);
+                        }
                       }}
                       title={
                         alreadyAssigned
@@ -468,7 +533,11 @@ export default function TeamBuilderPage() {
                           : "Add to active position"
                       }
                     >
-                      {alreadyAssigned ? "Assigned" : "Add"}
+                      {alreadyAssigned
+                        ? "Assigned"
+                        : savingPlayerIds.has(player.id)
+                        ? "Saving..."
+                        : "Add"}
                     </button>
                   </div>
                 );

--- a/server/routes/__init__.py
+++ b/server/routes/__init__.py
@@ -3,4 +3,3 @@ from .health import router as health_router
 from .players import router as players_router
 
 __all__ = ["auth_router", "health_router", "players_router"]
-


### PR DESCRIPTION

Integrated existing endpoints
Wire the Team Builder “Add” button into the existing /api/players/saved flow via playerActions.addPlayer.
Track all in-flight saves so each player’s button shows “Saving…” and stays disabled until its own POST finishes.
Keep the local savedPlayers list in sync by appending successful saves immediately.
Surface server errors inline above the search controls to alert users when a save fails.
No new backend endpoints or lineup persistence logic—everything relies on the existing saved-player CRUD APIs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time feedback during player operations with a loading indicator ("Saving...") and disabled button state to prevent duplicate submissions.
  * Added error handling with user-friendly error messages displayed when player save operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->