### PR TITLE
removed MLBteams page from side bar

### DIFF
--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -4,7 +4,6 @@ import {
   DashboardIcon,
   TeamBuilderIcon,
   TeamAnalysisIcon,
-  MLBTeamsIcon
 } from "@/assets/icons";
 import logo from "@/assets/brand_badge.jpg";
 import styles from "./Sidebar.module.css";
@@ -13,7 +12,6 @@ const navItems = [
   { label: "Dashboard", to: ROUTES.DASHBOARD, icon: DashboardIcon },
   { label: "Team Builder", to: ROUTES.TEAM_BUILDER, icon: TeamBuilderIcon },
   { label: "Team Analysis", to: ROUTES.TEAM_ANALYSIS, icon: TeamAnalysisIcon },
-  { label: "MLB Teams", to: ROUTES.MLB_TEAMS, icon: MLBTeamsIcon }
 ] as const;
 
 export default function Sidebar() {


### PR DESCRIPTION
closes #111 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the MLB Teams navigation option from the sidebar

<!-- end of auto-generated comment: release notes by coderabbit.ai -->