### PR TITLE
Fix: Reduce Firestore Reads by 99.5%

### DIFF
--- a/server/dependency/dependencies.py
+++ b/server/dependency/dependencies.py
@@ -54,7 +54,8 @@ def get_player_search_service():
 # roster avg related
 def get_roster_repository():
     """Create Firebase roster repository instance"""
-    return RosterRepositoryFirebase(firebase_service.db)
+    player_repo = get_player_repository()
+    return RosterRepositoryFirebase(firebase_service.db, player_repo)
 
 def get_roster_domain() -> RosterDomain:
     """Create roster domain instance"""

--- a/server/scripts/runner.py
+++ b/server/scripts/runner.py
@@ -65,7 +65,7 @@ async def run_all():
         log("Firebase not configured; aborting.")
         return
     player_repo = PlayerRepositoryFirebase(firebase_service.db)
-    roster_repo = RosterRepositoryFirebase(firebase_service.db)
+    roster_repo = RosterRepositoryFirebase(firebase_service.db, player_repo)
     run_seed_teams(player_repo, roster_repo)
     run_refresh_players(player_repo, roster_repo)
     await run_league(player_repo, roster_repo)


### PR DESCRIPTION
## Problem

The recommendation endpoint was generating **200k+ Firestore reads** under normal load, causing:
- Slow response times (multiple seconds per request)
- Firestore quota exhaustion
- Increased costs

### Root Cause

The [RosterRepositoryFirebase](cci:2://file:///c:/Users/Eeeta/School/Year%202/FTL/Cybermetrics/server/infrastructure/roster_repository.py:8:0-216:21) was hitting Firestore for every candidate player's season data during the recommendation loop, despite [PlayerRepositoryFirebase](cci:2://file:///c:/Users/Eeeta/School/Year%202/FTL/Cybermetrics/server/infrastructure/player_repository.py:12:0-208:17) already having all players cached in memory from an initial load.

**Example**: For a single recommendation request with 350 candidate shortstops:
- Step 2: Load current roster → 12 reads
- Step 4: Fetch league stats → 2 reads  
- **Step 9: Load each candidate's seasons → 350 reads**

**500 requests = ~182,000 Firestore reads**

## Solution

Injected `PlayerRepository` into [RosterRepositoryFirebase](cci:2://file:///c:/Users/Eeeta/School/Year%202/FTL/Cybermetrics/server/infrastructure/roster_repository.py:8:0-216:21) to reuse the existing in-memory player cache instead of making redundant Firestore calls.

### Changes Made

1. **[infrastructure/roster_repository.py](cci:7://file:///c:/Users/Eeeta/School/Year%202/FTL/Cybermetrics/server/infrastructure/roster_repository.py:0:0-0:0)**
   - Added `PlayerRepository` as constructor dependency
   - Replaced [get_players_seasons_data()](cci:1://file:///c:/Users/Eeeta/School/Year%202/FTL/Cybermetrics/server/repositories/roster_avg_repository.py:4:4-7:12) to use `player_repository._players_cache_by_id`
   - Added fallback to [get_player_by_id()](cci:1://file:///c:/Users/Eeeta/School/Year%202/FTL/Cybermetrics/server/infrastructure/player_repository.py:83:4-107:20) for cache misses (rare)

2. **[dependency/dependencies.py](cci:7://file:///c:/Users/Eeeta/School/Year%202/FTL/Cybermetrics/server/dependency/dependencies.py:0:0-0:0)**
   - Updated [get_roster_repository()](cci:1://file:///c:/Users/Eeeta/School/Year%202/FTL/Cybermetrics/server/dependency/dependencies.py:54:0-57:69) to inject `PlayerRepository` instance

3. **[scripts/runner.py](cci:7://file:///c:/Users/Eeeta/School/Year%202/FTL/Cybermetrics/server/scripts/runner.py:0:0-0:0)**
   - Updated [RosterRepositoryFirebase](cci:2://file:///c:/Users/Eeeta/School/Year%202/FTL/Cybermetrics/server/infrastructure/roster_repository.py:8:0-216:21) instantiation to pass `player_repo`

## Impact

### Firestore Reads Per Request

| Step | Before | After |
|------|--------|-------|
| Load roster seasons | 12 | 0 (cached) |
| League avg + std | 2 | 2 |
| **Load candidate seasons** | **350** | **0 (cached)** |
| **Total** | **~364** | **~2** |

### At Scale (500 requests)

- **Before**: 182,000 reads
- **After**: 1,000 reads
- **Reduction**: **99.5%**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data retrieval logic to leverage caching for improved performance when loading roster and player information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->