### PR TITLE
fix: Search Bar Auto Close Bug

### DIFF
--- a/client/src/pages/TeamBuilderPage/TeamBuilderPage.tsx
+++ b/client/src/pages/TeamBuilderPage/TeamBuilderPage.tsx
@@ -176,8 +176,6 @@ export default function TeamBuilderPage() {
     setSearchTerm(value);
     if (value.trim()) {
       setSearchModalOpen(true);
-    } else {
-      setSearchModalOpen(false);
     }
   }, []);
 


### PR DESCRIPTION
Fixes a bug not seen in the pr for isue #166 
Specificially, when a user open up the search model and types a player and then backspcaes and the input becomes empty, the modal auto closes

Solution: Deleted the logic that closes modal if input empty after typing into it. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search modal no longer closes automatically when the search term is cleared, allowing users to continue searching without needing to reopen it.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->