### PR TITLE
Feat: Add Expand Metrics Modal with Conditional Styling for Recommendations Radar Card

### DIFF
--- a/client/src/components/Recommendations/RecommendationsRadarCard.tsx
+++ b/client/src/components/Recommendations/RecommendationsRadarCard.tsx
@@ -317,16 +317,16 @@ export function RecommendationsRadarCard({
                     {baselineValue !== undefined ? (
                       <>
                         <div className={styles.statValueWithLabel}>
-                          <div className={`${styles.statComparisonValue} ${getStatColorClass(baselineValue)}`}>
+                          <div className={`${styles.statComparisonValue} ${getStatColorClass(baselineValue)} ${isModal ? styles.statComparisonValueModal : ''}`}>
                             {formatValue(baselineValue)}
                           </div>
-                          <div className={styles.statSubLabel}>std dev</div>
+                          <div className={`${styles.statSubLabel} ${isModal ? styles.statSubLabelModal : ''}`}>std dev</div>
                         </div>
                         <div className={styles.statPercentileWithLabel}>
-                          <div className={`${styles.statComparisonPercentile} ${getStatColorClass(baselineValue)}`}>
-                            {baselinePercentile}<span className={styles.percentileSuffix}>th</span>
+                          <div className={`${styles.statComparisonPercentile} ${getStatColorClass(baselineValue)} ${isModal ? styles.statComparisonPercentileModal : ''}`}>
+                            {baselinePercentile}<span className={`${styles.percentileSuffix} ${isModal ? styles.percentileSuffixModal : ''}`}>th</span>
                           </div>
-                          <div className={styles.statSubLabel}>percentile</div>
+                          <div className={`${styles.statSubLabel} ${isModal ? styles.statSubLabelModal : ''}`}>percentile</div>
                         </div>
                       </>
                     ) : (
@@ -335,28 +335,28 @@ export function RecommendationsRadarCard({
                   </div>
                   
                   {/* Delta and Arrow */}
-                  <div className={styles.statDeltaArrow}>
+                  <div className={`${styles.statDeltaArrow} ${isModal ? styles.statDeltaArrowModal : ''}`}>
                     {delta !== null && (
-                      <div className={`${styles.statDelta} ${getDeltaColorClass()}`}>
+                      <div className={`${styles.statDelta} ${getDeltaColorClass()} ${isModal ? styles.statDeltaModal : ''}`}>
                         {delta === 0 ? '0.00' : `${delta > 0 ? '+' : '-'}${Math.abs(delta).toFixed(2)}`}
                       </div>
                     )}
-                    <div className={styles.statArrow}>→</div>
+                    <div className={`${styles.statArrow} ${isModal ? styles.statArrowModal : ''}`}>→</div>
                   </div>
                   
                   {/* Current (After) */}
                   <div className={styles.statAfterGroup}>
                     <div className={styles.statValueWithLabel}>
-                      <div className={`${styles.statComparisonValue} ${getStatColorClass(currentValue)}`}>
+                      <div className={`${styles.statComparisonValue} ${getStatColorClass(currentValue)} ${isModal ? styles.statComparisonValueModal : ''}`}>
                         {formatValue(currentValue)}
                       </div>
-                      <div className={styles.statSubLabel}>std dev</div>
+                      <div className={`${styles.statSubLabel} ${isModal ? styles.statSubLabelModal : ''}`}>std dev</div>
                     </div>
                     <div className={styles.statPercentileWithLabel}>
-                      <div className={`${styles.statComparisonPercentile} ${getStatColorClass(currentValue)}`}>
-                        {currentPercentile}<span className={styles.percentileSuffix}>th</span>
+                      <div className={`${styles.statComparisonPercentile} ${getStatColorClass(currentValue)} ${isModal ? styles.statComparisonPercentileModal : ''}`}>
+                        {currentPercentile}<span className={`${styles.percentileSuffix} ${isModal ? styles.percentileSuffixModal : ''}`}>th</span>
                       </div>
-                      <div className={styles.statSubLabel}>percentile</div>
+                      <div className={`${styles.statSubLabel} ${isModal ? styles.statSubLabelModal : ''}`}>percentile</div>
                     </div>
                   </div>
                 </div>

--- a/client/src/pages/RecommendationsPage/components/RecommendationsView.module.css
+++ b/client/src/pages/RecommendationsPage/components/RecommendationsView.module.css
@@ -247,13 +247,6 @@
   flex: 0 0 8rem;
 }
 
-.statComparisonBlockModal .statComparisonValue {
-  font-size: 1.25rem;
-}
-
-.statComparisonBlockModal .statComparisonPercentile {
-  font-size: 1.25rem;
-}
 
 .statComparisonBlockModal .statSubLabel {
   font-size: 0.625rem;
@@ -320,10 +313,18 @@
   transition: color 0.4s ease;
 }
 
+.statComparisonValueModal {
+  font-size: 1.25rem !important;
+}
+
 .statComparisonPercentile {
   font-size: 0.9375rem;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
+}
+
+.statComparisonPercentileModal {
+  font-size: 1.25rem !important;
 }
 
 .statSubLabel {
@@ -333,6 +334,7 @@
   text-transform: uppercase;
   letter-spacing: 0.03em;
   margin-top: 0.125rem;
+  white-space: nowrap;
 }
 
 .percentileSuffix {
@@ -340,6 +342,14 @@
   font-weight: 600;
   color: rgba(255, 255, 255, 0.5);
   margin-left: 0.0625rem;
+}
+
+.percentileSuffixModal {
+  font-size: 0.875rem !important;
+}
+
+.statSubLabelModal {
+  font-size: 0.75rem !important;
 }
 
 .statDeltaArrow {
@@ -367,6 +377,20 @@
   font-weight: 300;
   text-align: center;
   width: 100%;
+}
+
+.statDeltaArrowModal {
+  width: 8rem;
+  gap: 0.2rem;
+}
+
+.statDeltaModal {
+  font-size: 1rem !important;
+  font-weight: 700 !important;
+}
+
+.statArrowModal {
+  font-size: 3rem !important;
 }
 
 .statPlaceholder {


### PR DESCRIPTION
## Summary
Added a modal view for the Recommendations Radar Card that displays larger version of the radar chart and performance metrics. 

## Changes
- Added Expand Metrics modal: Button wilopen full-screen modal 
- Implemented conditional styling system for different styling if modal is open or not
- Created label positioning overrides: Two separate Record configurations (LABEL_OVERRIDES_MODAL and LABEL_OVERRIDES_CARD) 
- Extracted reusable rendering logic: Created `renderRadarContent` function that accepts `isModal` parameter for both card and modal views

Closes #176 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Radar metrics card now supports expansion into a modal view for enhanced visibility and detailed analysis. The modal includes a dedicated header, optimized typography, and improved spacing for metric comparison. Users can dismiss the modal by clicking outside.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->